### PR TITLE
138-save-the-user-id-to-local-storage

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.11.1"
+agp = "8.12.0"
 androidGpxParser = "2.3.1"
 coilComposeVersion = "2.7.0"
 composeMaterialVersion = "1.4.1"

--- a/mobile/src/main/java/com/ontrek/mobile/screens/NavigationStack.kt
+++ b/mobile/src/main/java/com/ontrek/mobile/screens/NavigationStack.kt
@@ -32,6 +32,7 @@ fun NavigationStack(modifier: Modifier = Modifier) {
                 ProfileScreen(
                     navController = navController,
                     token = preferencesViewModel.tokenState.value ?: "",
+                    currentUser = preferencesViewModel.currentUserState.value ?: "",
                     clearToken = {
                         preferencesViewModel.clearToken()
                     },

--- a/mobile/src/main/java/com/ontrek/mobile/screens/profile/ProfileScreen.kt
+++ b/mobile/src/main/java/com/ontrek/mobile/screens/profile/ProfileScreen.kt
@@ -46,6 +46,7 @@ import com.ontrek.mobile.utils.components.ErrorViewComponent
 fun ProfileScreen(
     navController: NavHostController,
     token: String,
+    currentUser: String,
     clearToken: () -> Unit
 ) {
     val context = LocalContext.current
@@ -254,7 +255,7 @@ fun ProfileScreen(
                     ConnectionWearButton(
                         connectionState = connectionStatus,
                         onConnectClick = {
-                            viewModel.sendAuthToWearable(context, token)
+                            viewModel.sendAuthToWearable(context, token, currentUser)
                         },
                         onDeleteClick = { showDeleteDialog = true }
                     )

--- a/mobile/src/main/java/com/ontrek/mobile/screens/profile/ProfileViewModel.kt
+++ b/mobile/src/main/java/com/ontrek/mobile/screens/profile/ProfileViewModel.kt
@@ -82,13 +82,14 @@ class ProfileViewModel : ViewModel() {
         }
     }
 
-    fun sendAuthToWearable(context: Context, token: String) {
+    fun sendAuthToWearable(context: Context, token: String, userID: String) {
         viewModelScope.launch {
             _connectionStatusWaer.value = ConnectionState.Loading
             try {
                 val putDataMapReq = PutDataMapRequest.create("/auth").apply {
                     dataMap.putString("token", token)
                     dataMap.putLong("timestamp", System.currentTimeMillis())
+                    dataMap.putString("user", userID)
                 }
                 val request = putDataMapReq.asPutDataRequest().setUrgent()
 

--- a/mobile/src/main/java/com/ontrek/mobile/screens/profile/ProfileViewModel.kt
+++ b/mobile/src/main/java/com/ontrek/mobile/screens/profile/ProfileViewModel.kt
@@ -89,7 +89,7 @@ class ProfileViewModel : ViewModel() {
                 val putDataMapReq = PutDataMapRequest.create("/auth").apply {
                     dataMap.putString("token", token)
                     dataMap.putLong("timestamp", System.currentTimeMillis())
-                    dataMap.putString("user", userID)
+                    dataMap.putString("currentUser", userID)
                 }
                 val request = putDataMapReq.asPutDataRequest().setUrgent()
 

--- a/wear/src/main/java/com/ontrek/wear/MainActivity.kt
+++ b/wear/src/main/java/com/ontrek/wear/MainActivity.kt
@@ -134,6 +134,7 @@ class MainActivity : ComponentActivity(), DataClient.OnDataChangedListener {
             ) {
                 val dataMap = DataMapItem.fromDataItem(event.dataItem).dataMap
                 preferencesViewModel.saveToken(dataMap.getString("token") ?: "")
+                preferencesViewModel.saveCurrentUser(dataMap.getString("currentUser") ?: "")
             }
         }
     }

--- a/wear/src/main/java/com/ontrek/wear/data/PreferencesStore.kt
+++ b/wear/src/main/java/com/ontrek/wear/data/PreferencesStore.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.map
 class PreferencesStore(private val dataStore: DataStore<Preferences>) {
     private companion object {
         val TOKEN = stringPreferencesKey("token")
+        val CURRENT_USER = stringPreferencesKey("currentUser")
     }
 
     val currentToken: Flow<String> =
@@ -17,9 +18,20 @@ class PreferencesStore(private val dataStore: DataStore<Preferences>) {
             preferences[TOKEN] ?: ""
         }
 
+    val currentUser: Flow<String> =
+        dataStore.data.map { preferences ->
+            preferences[CURRENT_USER] ?: ""
+        }
+
     suspend fun saveToken(token: String) {
         dataStore.edit { preferences ->
             preferences[TOKEN] = token
+        }
+    }
+
+    suspend fun saveCurrentUser(userId: String) {
+        dataStore.edit { preferences ->
+            preferences[CURRENT_USER] = userId
         }
     }
 

--- a/wear/src/main/java/com/ontrek/wear/data/PreferencesViewModel.kt
+++ b/wear/src/main/java/com/ontrek/wear/data/PreferencesViewModel.kt
@@ -33,9 +33,22 @@ class PreferencesViewModel(
             initialValue = null
         )
 
+    val currentUserState: StateFlow<String?> =
+        preferencesStore.currentUser.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = null
+        )
+
     fun saveToken(userName: String) {
         viewModelScope.launch {
             preferencesStore.saveToken(userName)
+        }
+    }
+
+    fun saveCurrentUser(userId: String) {
+        viewModelScope.launch {
+            preferencesStore.saveCurrentUser(userId)
         }
     }
 


### PR DESCRIPTION
Creata la funzione nello storage per prendere e salvare l'user in wear, e anche per riceverlo dal cellulare connettendolo